### PR TITLE
Ensures the pom declares this as a BSD project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,13 @@
     <packaging>jar</packaging>
 
     <name>Roguelike Library For Java (Alternative version)</name>
+  
+    <licenses>
+        <license>
+            <name>BSD-3-Clause</name>
+            <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+    </licenses>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Identifies the license terms outlined in the project readme in the pom as well. This ensures that dependents using the org.mojohaus license-maven-plugin are able to resolve the intended license.